### PR TITLE
[Feature] Add User, WorkItem, UserWorkItemStatus, and Token entity models

### DIFF
--- a/Models/Token.cs
+++ b/Models/Token.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MyWorkItemManagement.Models
+{
+    public class Token
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+        public int UserId { get; set; }
+
+        [Column("Token")]
+        public string TokenValue { get; set; }
+        public DateTime CreateAt { get; set; }
+        public DateTime ExpiredAt { get; set; }
+        public bool IsLogout { get; set; }
+
+        [ForeignKey(nameof(UserId))]
+        public User User { get; set; }
+    }
+}

--- a/Models/Token.cs
+++ b/Models/Token.cs
@@ -12,9 +12,9 @@ namespace MyWorkItemManagement.Models
 
         [Column("Token")]
         public string TokenValue { get; set; }
-        public DateTime CreateAt { get; set; }
-        public DateTime ExpiredAt { get; set; }
-        public bool IsLogout { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime ExpiresAt { get; set; }
+        public bool IsLoggedOut { get; set; }
 
         [ForeignKey(nameof(UserId))]
         public User User { get; set; }

--- a/Models/User.cs
+++ b/Models/User.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MyWorkItemManagement.Models
+{
+    public class User
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+        public string Username { get; set; }
+        public string PasswordHash { get; set; }
+        public string PasswordSalt { get; set; }
+        public int RoleId { get; set; }
+
+        [ForeignKey(nameof(RoleId))]
+        public Role Role { get; set; }
+
+        public ICollection<UserWorkItemStatus> UserWorkItemStatuses { get; set; }
+        public ICollection<Token> Tokens { get; set; }
+    }
+}

--- a/Models/User.cs
+++ b/Models/User.cs
@@ -16,7 +16,7 @@ namespace MyWorkItemManagement.Models
         [ForeignKey(nameof(RoleId))]
         public Role Role { get; set; }
 
-        public ICollection<UserWorkItemStatus> UserWorkItemStatuses { get; set; }
-        public ICollection<Token> Tokens { get; set; }
+        public ICollection<UserWorkItemStatus> UserWorkItemStatuses { get; set; } = new HashSet<UserWorkItemStatus>();
+        public ICollection<Token> Tokens { get; set; } = new HashSet<Token>();
     }
 }

--- a/Models/UserWorkItemStatus.cs
+++ b/Models/UserWorkItemStatus.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MyWorkItemManagement.Models
+{
+    public class UserWorkItemStatus
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+        public int UserId { get; set; }
+        public int WorkItemId { get; set; }
+        public bool IsConfirmed { get; set; }
+
+        [ForeignKey(nameof(UserId))]
+        public User User { get; set; }
+
+        [ForeignKey(nameof(WorkItemId))]
+        public WorkItem WorkItem { get; set; }
+    }
+}

--- a/Models/UserWorkItemStatus.cs
+++ b/Models/UserWorkItemStatus.cs
@@ -1,8 +1,10 @@
+using Microsoft.EntityFrameworkCore;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace MyWorkItemManagement.Models
 {
+    [Index(nameof(UserId), nameof(WorkItemId), IsUnique = true)]
     public class UserWorkItemStatus
     {
         [Key]

--- a/Models/WorkItem.cs
+++ b/Models/WorkItem.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MyWorkItemManagement.Models
+{
+    public class WorkItem
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public string? Description { get; set; }
+
+        public ICollection<UserWorkItemStatus> UserWorkItemStatuses { get; set; }
+    }
+}

--- a/Models/WorkItem.cs
+++ b/Models/WorkItem.cs
@@ -11,6 +11,6 @@ namespace MyWorkItemManagement.Models
         public string Title { get; set; }
         public string? Description { get; set; }
 
-        public ICollection<UserWorkItemStatus> UserWorkItemStatuses { get; set; }
+        public ICollection<UserWorkItemStatus> UserWorkItemStatuses { get; set; } = new HashSet<UserWorkItemStatus>();
     }
 }


### PR DESCRIPTION
## Summary

Adds the four remaining EF Core POCO entities so the data model matches the schema diagram in issue #2 (comment 1). This is checklist item 1 of issue #3 — entity classes only; `DbSet` registration, Fluent API relationship config, and the migration come in follow-up commits.

- `User` — `Id`, `Username`, `PasswordHash`, `PasswordSalt`, `RoleId` FK + navigation to `Role` and reverse collections (`UserWorkItemStatuses`, `Tokens`).
- `WorkItem` — `Id`, `Title`, nullable `Description` (matches diagram), reverse collection to `UserWorkItemStatus`.
- `UserWorkItemStatus` — junction table for the User ↔ WorkItem M:N relationship; tracks per-user `IsConfirmed`.
- `Token` — login session record. The DB column is `Token` (per the diagram) but the property is `TokenValue` with `[Column("Token")]` to avoid CS0542 (member name same as enclosing type).

All entities follow the existing `Role` POCO pattern: `[Key]` + `[DatabaseGenerated(Identity)]` on `Id`, FKs paired with `[ForeignKey]`-annotated navigation properties.

## Why

Required precursor for the auth flow, RBAC, and per-user WorkItem confirmation features described in `README.md`. Splitting checklist item 1 from items 2–4 keeps the diff small and reviewable, and lets the snapshot/migration land in its own commit.

## Test plan

- [x] `dotnet build` succeeds with 0 errors. New CS8618 warnings match the existing `Role.cs` pattern (no regression).
- [ ] Reviewer to confirm field names/types match the schema diagram in issue #2 comment 1.
- [ ] After merge: follow-up will register `DbSet`s on `AppDbContext`, configure Fluent API (recommend `OnDelete(Restrict)` on `UserWorkItemStatus` to avoid SQL Server multiple-cascade-paths), and run `dotnet ef migrations add AddUserAndWorkItem`.

Refs #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)